### PR TITLE
[FIX] l10n_br_nfe: evitar erro 'Invalid field uom.uom.code' ao import…

### DIFF
--- a/l10n_br_nfe/wizards/import_document.py
+++ b/l10n_br_nfe/wizards/import_document.py
@@ -115,8 +115,8 @@ class NfeImport(models.TransientModel):
             uom_id = self.env["uom.uom"].search(
                 [
                     "|",
-                    ("code", "=", product.prod.uCom),
-                    ("code", "=", product.prod.uTrib),
+                    ("alias_ids.code", "=", product.prod.uCom),
+                    ("alias_ids.code", "=", product.prod.uTrib),
                 ],
                 limit=1,
             )


### PR DESCRIPTION
Corrige um erro ao importar XMLs de Nota Fiscal Eletrônica (modelo 55) no módulo `l10n_br_nfe`.

### Erro encontrado
Durante a importação, o sistema tenta buscar a unidade de medida (`uom_id`) com o campo `code` diretamente no modelo `uom.uom`, o que resulta no erro abaixo:

**ValueError: Invalid field uom.uom.code in leaf ('code', '=', 'PC')**

Esse campo não existe no modelo `uom.uom`, mas sim no modelo `uom.alias`, relacionado via o campo `alias_ids`.

### Correção aplicada
O código foi ajustado para usar corretamente o domínio com `alias_ids.code`:

```python
uom_id = self.env["uom.uom"].search(
    [
        "|",
        ("alias_ids.code", "=", product.prod.uCom),
        ("alias_ids.code", "=", product.prod.uTrib),
    ],
    limit=1,
)